### PR TITLE
Migrate to Move 2024

### DIFF
--- a/move/blackjack/Move.toml
+++ b/move/blackjack/Move.toml
@@ -1,6 +1,7 @@
 [package]
 name = "blackjack"
 version = "0.0.1"
+edition = "2024.beta"
 
 [dependencies]
 Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet" }

--- a/move/blackjack/sources/counter_nft.move
+++ b/move/blackjack/sources/counter_nft.move
@@ -6,14 +6,10 @@
 /// The counter NFT is non transferable, i.e. it can only be ever owned by one account.
 module blackjack::counter_nft {
     // Imports
-    use std::vector;
-    use sui::object::{Self, UID};
-    use sui::tx_context::{Self, TxContext};
-    use sui::transfer::{Self};
     use sui::bcs::{Self};
 
     // Structs
-    struct Counter has key {
+    public struct Counter has key {
         id: UID,
         count: u64,
     }
@@ -26,7 +22,7 @@ module blackjack::counter_nft {
             count: 0
         };
 
-        transfer::transfer(counter, tx_context::sender(ctx));
+        transfer::transfer(counter, ctx.sender());
     }
 
     /// Internal function to increment the counter by 1.
@@ -36,10 +32,10 @@ module blackjack::counter_nft {
 
     /// Calculates the Counter NFT ID + count. Then it increases the count by 1 and returns the appended bytes.
     public fun increment_and_get(self: &mut Counter): vector<u8> {
-        let vrf_input = object::id_bytes(self);
+        let mut vrf_input = object::id_bytes(self);
         let count_to_bytes = bcs::to_bytes(&count(self));
-        vector::append(&mut vrf_input, count_to_bytes);
-        increment(self);
+        vrf_input.append(count_to_bytes);
+        self.increment();
         vrf_input
     }
 

--- a/move/blackjack/tests/blackjack_tests.move
+++ b/move/blackjack/tests/blackjack_tests.move
@@ -65,7 +65,7 @@ module blackjack::single_player_blackjack_tests {
 
     #[test]
     fun test_bls_signature_for_first_deal() {
-        let messageVector = GAME_RANDOMNESS;
+        let mut messageVector = GAME_RANDOMNESS;
         vector::append(&mut messageVector, vector<u8> [0]);
         let bls_sig = BLS_SIG_0;
         let house_public_key = HOUSE_PUBLIC_KEY;
@@ -79,7 +79,7 @@ module blackjack::single_player_blackjack_tests {
 
     #[test]
     fun test_initialize_house_data() {
-        let scenario_val = test_scenario::begin(ADMIN);
+        let mut scenario_val = test_scenario::begin(ADMIN);
         let scenario = &mut scenario_val;
 
         initialize_house_data_for_test(scenario, ADMIN, INITIAL_HOUSE_BALANCE);
@@ -104,7 +104,7 @@ module blackjack::single_player_blackjack_tests {
 
     #[test]
     fun test_top_up_house_data() {
-        let scenario_val = test_scenario::begin(ADMIN);
+        let mut scenario_val = test_scenario::begin(ADMIN);
         let scenario = &mut scenario_val;
 
         initialize_house_data_for_test(scenario, ADMIN, INITIAL_HOUSE_BALANCE);
@@ -117,7 +117,7 @@ module blackjack::single_player_blackjack_tests {
 
         test_scenario::next_tx(scenario, ADMIN);
         {
-            let house_data = test_scenario::take_shared<HouseData>(scenario);
+            let mut house_data = test_scenario::take_shared<HouseData>(scenario);
             let fund_coin = test_scenario::take_from_sender<Coin<SUI>>(scenario);
             bj::top_up(&mut house_data, fund_coin, test_scenario::ctx(scenario));
             test_scenario::return_shared(house_data);
@@ -135,14 +135,14 @@ module blackjack::single_player_blackjack_tests {
 
     #[test]
     fun test_withdraw_from_house_data() {
-        let scenario_val = test_scenario::begin(ADMIN);
+        let mut scenario_val = test_scenario::begin(ADMIN);
         let scenario = &mut scenario_val;
 
         initialize_house_data_for_test(scenario, ADMIN, INITIAL_HOUSE_BALANCE);
 
         test_scenario::next_tx(scenario, ADMIN);
         {
-            let house_data = test_scenario::take_shared<HouseData>(scenario);
+            let mut house_data = test_scenario::take_shared<HouseData>(scenario);
             bj::withdraw(&mut house_data, test_scenario::ctx(scenario));
             test_scenario::return_shared(house_data);
         };
@@ -160,7 +160,7 @@ module blackjack::single_player_blackjack_tests {
     #[test]
     #[expected_failure(abort_code = bj::EInsufficientBalance)]
     fun test_initialize_house_data_with_insifficient_balance() {
-        let scenario_val = test_scenario::begin(ADMIN);
+        let mut scenario_val = test_scenario::begin(ADMIN);
         let scenario = &mut scenario_val;
 
         initialize_house_data_for_test(scenario, ADMIN, 0);
@@ -170,7 +170,7 @@ module blackjack::single_player_blackjack_tests {
 
     #[test]
     fun test_place_bet_and_create_game() {
-        let scenario_val = test_scenario::begin(PLAYER);
+        let mut scenario_val = test_scenario::begin(PLAYER);
         let scenario = &mut scenario_val;
 
         initialize_house_data_for_test(scenario, ADMIN, INITIAL_HOUSE_BALANCE);
@@ -195,7 +195,7 @@ module blackjack::single_player_blackjack_tests {
     #[test]
     #[expected_failure(abort_code = bj::EInsufficientHouseBalance)]
     fun test_place_bet_and_create_game_insufficient_house_balance() {
-        let scenario_val = test_scenario::begin(ADMIN);
+        let mut scenario_val = test_scenario::begin(ADMIN);
         let scenario = &mut scenario_val;
 
         initialize_house_data_for_test(scenario, ADMIN, HOUSE_BET - 1);
@@ -207,7 +207,7 @@ module blackjack::single_player_blackjack_tests {
     #[test]
     #[expected_failure(abort_code = bj::EInvalidPlayerBetAmount)]
     fun test_place_bet_and_create_game_insufficient_balance() {
-        let scenario_val = test_scenario::begin(ADMIN);
+        let mut scenario_val = test_scenario::begin(ADMIN);
         let scenario = &mut scenario_val;
 
         initialize_house_data_for_test(scenario, ADMIN, INITIAL_HOUSE_BALANCE);
@@ -218,7 +218,7 @@ module blackjack::single_player_blackjack_tests {
 
     #[test]
     fun test_first_deal() {
-        let scenario_val = test_scenario::begin(PLAYER);
+        let mut scenario_val = test_scenario::begin(PLAYER);
         let scenario = &mut scenario_val;
 
         initialize_house_data_for_test(scenario, ADMIN, INITIAL_HOUSE_BALANCE);
@@ -241,7 +241,7 @@ module blackjack::single_player_blackjack_tests {
      #[test]
      #[expected_failure(abort_code = bj::EInvalidBlsSig)]
     fun test_first_deal_with_invalid_bls_sig() {
-        let scenario_val = test_scenario::begin(PLAYER);
+        let mut scenario_val = test_scenario::begin(PLAYER);
         let scenario = &mut scenario_val;
 
         initialize_house_data_for_test(scenario, ADMIN, INITIAL_HOUSE_BALANCE);
@@ -254,7 +254,7 @@ module blackjack::single_player_blackjack_tests {
     #[test]
     #[expected_failure(abort_code = bj::EDealAlreadyHappened)]
     public fun test_first_deal_twice() {
-        let scenario_val = test_scenario::begin(ADMIN);
+        let mut scenario_val = test_scenario::begin(ADMIN);
         let scenario = &mut scenario_val;
 
         initialize_house_data_for_test(scenario, ADMIN, INITIAL_HOUSE_BALANCE);
@@ -267,17 +267,17 @@ module blackjack::single_player_blackjack_tests {
 
     #[test]
     fun test_hit() {
-        let scenario_val = test_scenario::begin(PLAYER);
+        let mut scenario_val = test_scenario::begin(PLAYER);
         let scenario = &mut scenario_val;
 
         initialize_house_data_for_test(scenario, ADMIN, INITIAL_HOUSE_BALANCE);
         initialize_game_for_test(scenario, PLAYER, PLAYER_BET);
         do_first_deal_for_test(scenario, ADMIN, BLS_SIG_0, false);
 
-        let _player_sum_before: u8 = 0;
-        let _player_cards_before: vector<u8> = vector<u8>[];
-        let _dealer_sum_before: u8 = 0;
-        let _dealer_cards_before: vector<u8> = vector<u8>[];
+        let mut _player_sum_before: u8 = 0;
+        let mut _player_cards_before: vector<u8> = vector<u8>[];
+        let mut _dealer_sum_before: u8 = 0;
+        let mut _dealer_cards_before: vector<u8> = vector<u8>[];
 
         test_scenario::next_tx(scenario, PLAYER);
         {
@@ -314,17 +314,17 @@ module blackjack::single_player_blackjack_tests {
 
     #[test]
     fun test_stand() {
-        let scenario_val = test_scenario::begin(PLAYER);
+        let mut scenario_val = test_scenario::begin(PLAYER);
         let scenario = &mut scenario_val;
 
         initialize_house_data_for_test(scenario, ADMIN, INITIAL_HOUSE_BALANCE);
         initialize_game_for_test(scenario, PLAYER, PLAYER_BET);
         do_first_deal_for_test(scenario, ADMIN, BLS_SIG_0, false);
 
-        let _player_sum_before: u8 = 0;
-        let _player_cards_before: vector<u8> = vector<u8>[];
-        let _dealer_sum_before: u8 = 0;
-        let _dealer_cards_before: vector<u8> = vector<u8>[];
+        let mut _player_sum_before: u8 = 0;
+        let mut _player_cards_before: vector<u8> = vector<u8>[];
+        let mut _dealer_sum_before: u8 = 0;
+        let mut _dealer_cards_before: vector<u8> = vector<u8>[];
 
         test_scenario::next_tx(scenario, PLAYER);
         {
@@ -361,7 +361,7 @@ module blackjack::single_player_blackjack_tests {
 
     #[test]
     fun test_do_hit() {
-        let scenario_val = test_scenario::begin(PLAYER);
+        let mut scenario_val = test_scenario::begin(PLAYER);
         let scenario = &mut scenario_val;
 
         initialize_house_data_for_test(scenario, PLAYER, INITIAL_HOUSE_BALANCE);
@@ -387,7 +387,7 @@ module blackjack::single_player_blackjack_tests {
     #[test]
     #[expected_failure(abort_code = bj::EGameHasFinished)]
     fun test_do_hit_in_finished_game() {
-        let scenario_val = test_scenario::begin(PLAYER);
+        let mut scenario_val = test_scenario::begin(PLAYER);
         let scenario = &mut scenario_val;
 
         initialize_house_data_for_test(scenario, ADMIN, INITIAL_HOUSE_BALANCE);
@@ -402,7 +402,7 @@ module blackjack::single_player_blackjack_tests {
     #[test]
     #[expected_failure(abort_code = bj::EUnauthorizedPlayer)]
     fun test_do_hit_unauthorized() {
-        let scenario_val = test_scenario::begin(PLAYER);
+        let mut scenario_val = test_scenario::begin(PLAYER);
         let scenario = &mut scenario_val;
         let player2 = @0xBBBB;
 
@@ -417,7 +417,7 @@ module blackjack::single_player_blackjack_tests {
     #[test]
     #[expected_failure(abort_code = bj::EInvalidSumOfHitRequest)]
     fun test_do_hit_with_invalid_player_sum() {
-        let scenario_val = test_scenario::begin(PLAYER);
+        let mut scenario_val = test_scenario::begin(PLAYER);
         let scenario = &mut scenario_val;
 
         initialize_house_data_for_test(scenario, ADMIN, INITIAL_HOUSE_BALANCE);
@@ -426,7 +426,7 @@ module blackjack::single_player_blackjack_tests {
         
         test_scenario::next_tx(scenario, PLAYER);
         {
-            let game = test_scenario::take_shared<Game>(scenario);
+            let mut game = test_scenario::take_shared<Game>(scenario);
             let current_player_sum = bj::player_sum(&game);
             let hit_request = bj::do_hit(
                 &mut game,
@@ -445,7 +445,7 @@ module blackjack::single_player_blackjack_tests {
 
     #[test]
     fun test_to_stand() {
-        let scenario_val = test_scenario::begin(PLAYER);
+        let mut scenario_val = test_scenario::begin(PLAYER);
         let scenario = &mut scenario_val;
 
         initialize_house_data_for_test(scenario, PLAYER, INITIAL_HOUSE_BALANCE);
@@ -471,7 +471,7 @@ module blackjack::single_player_blackjack_tests {
     #[test]
     #[expected_failure(abort_code = bj::EGameHasFinished)]
     fun test_do_stand_in_finished_game() {
-        let scenario_val = test_scenario::begin(PLAYER);
+        let mut scenario_val = test_scenario::begin(PLAYER);
         let scenario = &mut scenario_val;
 
         initialize_house_data_for_test(scenario, ADMIN, INITIAL_HOUSE_BALANCE);
@@ -485,7 +485,7 @@ module blackjack::single_player_blackjack_tests {
     #[test]
     #[expected_failure(abort_code = bj::EUnauthorizedPlayer)]
     fun test_do_stand_unauthorized() {
-        let scenario_val = test_scenario::begin(PLAYER);
+        let mut scenario_val = test_scenario::begin(PLAYER);
         let scenario = &mut scenario_val;
         let player2 = @0xBBBB;
 
@@ -500,7 +500,7 @@ module blackjack::single_player_blackjack_tests {
     #[test]
     #[expected_failure(abort_code = bj::EInvalidSumOfStandRequest)]
     fun test_do_stand_with_invalid_player_sum() {
-        let scenario_val = test_scenario::begin(PLAYER);
+        let mut scenario_val = test_scenario::begin(PLAYER);
         let scenario = &mut scenario_val;
 
         initialize_house_data_for_test(scenario, ADMIN, INITIAL_HOUSE_BALANCE);
@@ -509,7 +509,7 @@ module blackjack::single_player_blackjack_tests {
         
         test_scenario::next_tx(scenario, PLAYER);
         {
-            let game = test_scenario::take_shared<Game>(scenario);
+            let mut game = test_scenario::take_shared<Game>(scenario);
             let current_player_sum = bj::player_sum(&game);
             let stand_request = bj::do_stand(
                 &mut game,
@@ -528,7 +528,7 @@ module blackjack::single_player_blackjack_tests {
 
     #[test]
     fun test_player_won_post_handling() {
-        let scenario_val = test_scenario::begin(PLAYER);
+        let mut scenario_val = test_scenario::begin(PLAYER);
         let scenario = &mut scenario_val;
         initialize_house_data_for_test(scenario, ADMIN, INITIAL_HOUSE_BALANCE);
         initialize_game_for_test(scenario, PLAYER, PLAYER_BET);
@@ -550,7 +550,7 @@ module blackjack::single_player_blackjack_tests {
 
     #[test]
     fun test_house_won_post_handling() {
-        let scenario_val = test_scenario::begin(PLAYER);
+        let mut scenario_val = test_scenario::begin(PLAYER);
         let scenario = &mut scenario_val;
         initialize_house_data_for_test(scenario, ADMIN, INITIAL_HOUSE_BALANCE);
         initialize_game_for_test(scenario, PLAYER, PLAYER_BET);
@@ -572,7 +572,7 @@ module blackjack::single_player_blackjack_tests {
 
     #[test]
     fun test_tie_post_handling() {
-        let scenario_val = test_scenario::begin(PLAYER);
+        let mut scenario_val = test_scenario::begin(PLAYER);
         let scenario = &mut scenario_val;
         initialize_house_data_for_test(scenario, ADMIN, INITIAL_HOUSE_BALANCE);
         initialize_game_for_test(scenario, PLAYER, PLAYER_BET);
@@ -596,7 +596,7 @@ module blackjack::single_player_blackjack_tests {
     // Test a whole flow where the user exceeds total sum of 21.
     #[test]
     fun test_player_exceeds_21() {
-        let scenario_val = test_scenario::begin(PLAYER);
+        let mut scenario_val = test_scenario::begin(PLAYER);
         let scenario = &mut scenario_val;
 
         initialize_house_data_for_test(scenario, ADMIN, INITIAL_HOUSE_BALANCE);
@@ -656,9 +656,9 @@ module blackjack::single_player_blackjack_tests {
 
         test_scenario::next_tx(scenario, player);
         {
-            let counter = test_scenario::take_from_sender<Counter>(scenario);
+            let mut counter = test_scenario::take_from_sender<Counter>(scenario);
             let coin = coin::mint_for_testing<SUI>(balance, test_scenario::ctx(scenario));
-            let house_data = test_scenario::take_shared<HouseData>(scenario);
+            let mut house_data = test_scenario::take_shared<HouseData>(scenario);
             bj::place_bet_and_create_game(
                 // Just a placeholder for the user_randomness.
                 // Will be replaced with a hard-coded value in the testing flow
@@ -675,7 +675,7 @@ module blackjack::single_player_blackjack_tests {
 
         test_scenario::next_tx(scenario, player);
         {
-            let game = test_scenario::take_shared<Game>(scenario);
+            let mut game = test_scenario::take_shared<Game>(scenario);
             bj::set_game_randomness_for_testing(
                 GAME_RANDOMNESS,
                 &mut game,
@@ -693,8 +693,8 @@ module blackjack::single_player_blackjack_tests {
     ) {
         test_scenario::next_tx(scenario, admin);
         {
-            let game = test_scenario::take_shared<Game>(scenario);
-            let house_data = test_scenario::take_shared<HouseData>(scenario);
+            let mut game = test_scenario::take_shared<Game>(scenario);
+            let mut house_data = test_scenario::take_shared<HouseData>(scenario);
             bj::first_deal(
                 &mut game,
                 bls_sig,
@@ -723,7 +723,7 @@ module blackjack::single_player_blackjack_tests {
     ) {
         test_scenario::next_tx(scenario, player);
         {
-            let game = test_scenario::take_shared<Game>(scenario);
+            let mut game = test_scenario::take_shared<Game>(scenario);
             let current_player_sum = bj::player_sum(&game);
             let hit_request = bj::do_hit(
                 &mut game,
@@ -745,7 +745,7 @@ module blackjack::single_player_blackjack_tests {
     ) {
         let effects = test_scenario::next_tx(scenario, player);
         {
-            let game = test_scenario::take_shared<Game>(scenario);
+            let mut game = test_scenario::take_shared<Game>(scenario);
             let current_player_sum = bj::player_sum(&game);
             let stand_request = bj::do_stand(
                 &mut game,
@@ -768,8 +768,8 @@ module blackjack::single_player_blackjack_tests {
     ) {
         test_scenario::next_tx(scenario, admin);
         {
-            let game = test_scenario::take_shared<Game>(scenario);
-            let house_data = test_scenario::take_shared<HouseData>(scenario);
+            let mut game = test_scenario::take_shared<Game>(scenario);
+            let mut house_data = test_scenario::take_shared<HouseData>(scenario);
             let hit_request = test_scenario::take_from_sender<HitRequest>(scenario);
             bj::hit(
                 &mut game,
@@ -790,8 +790,8 @@ module blackjack::single_player_blackjack_tests {
     ) {
         test_scenario::next_tx(scenario, admin);
         {
-            let game = test_scenario::take_shared<Game>(scenario);
-            let house_data = test_scenario::take_shared<HouseData>(scenario);
+            let mut game = test_scenario::take_shared<Game>(scenario);
+            let mut house_data = test_scenario::take_shared<HouseData>(scenario);
             let stand_request = test_scenario::take_from_sender<StandRequest>(scenario);
             bj::stand(
                 &mut game,
@@ -812,7 +812,7 @@ module blackjack::single_player_blackjack_tests {
     ) {
         test_scenario::next_tx(scenario, player);
         {
-            let game = test_scenario::take_shared<Game>(scenario);
+            let mut game = test_scenario::take_shared<Game>(scenario);
             let card = 6; // calculated value for card is 7
             bj::draw_player_card_for_testing(
                 &mut game,
@@ -838,7 +838,7 @@ module blackjack::single_player_blackjack_tests {
     ) {
         test_scenario::next_tx(scenario, admin);
         {
-            let game = test_scenario::take_shared<Game>(scenario);
+            let mut game = test_scenario::take_shared<Game>(scenario);
             bj::player_won_post_handling_for_test(
                 &mut game,
                 test_scenario::ctx(scenario),
@@ -853,8 +853,8 @@ module blackjack::single_player_blackjack_tests {
     ) {
         test_scenario::next_tx(scenario, admin);
         {
-            let game = test_scenario::take_shared<Game>(scenario);
-            let house_data = test_scenario::take_shared<HouseData>(scenario);
+            let mut game = test_scenario::take_shared<Game>(scenario);
+            let mut house_data = test_scenario::take_shared<HouseData>(scenario);
             bj::house_won_post_handling_for_test(
                 &mut game,
                 &mut house_data,
@@ -871,8 +871,8 @@ module blackjack::single_player_blackjack_tests {
     ) {
         test_scenario::next_tx(scenario, admin);
         {
-            let game = test_scenario::take_shared<Game>(scenario);
-            let house_data = test_scenario::take_shared<HouseData>(scenario);
+            let mut game = test_scenario::take_shared<Game>(scenario);
+            let mut house_data = test_scenario::take_shared<HouseData>(scenario);
             bj::tie_post_handling_for_test(
                 &mut game,
                 &mut house_data,

--- a/move/blackjack/tests/blackjack_tests.move
+++ b/move/blackjack/tests/blackjack_tests.move
@@ -4,14 +4,10 @@
 #[test_only]
 module blackjack::single_player_blackjack_tests {
 
-    use std::vector;
     use std::debug;
     use std::string::utf8;
-    use sui::object::{ID};
     use sui::coin::{Coin, Self};
     use sui::sui::SUI;
-    use sui::object;
-    use sui::transfer;
     use sui::test_scenario::{Self, Scenario};
     use sui::bls12381::bls12381_min_pk_verify;
     use blackjack::single_player_blackjack::{Self as bj, HouseAdminCap, HouseData, Game, HitRequest, StandRequest};
@@ -22,7 +18,7 @@ module blackjack::single_player_blackjack_tests {
     const INITIAL_HOUSE_BALANCE: u64 = 5000000000;
     const PLAYER_BET: u64 = 200000000;
     const HOUSE_BET: u64 =  200000000;
-    
+
     const HOUSE_PUBLIC_KEY: vector<u8> = vector<u8> [
         185, 195,  27,  41,  48, 111, 208,  32,  77,
         189, 168,  94,  72, 179, 194, 183,  67, 237,
@@ -66,7 +62,7 @@ module blackjack::single_player_blackjack_tests {
     #[test]
     fun test_bls_signature_for_first_deal() {
         let mut messageVector = GAME_RANDOMNESS;
-        vector::append(&mut messageVector, vector<u8> [0]);
+        messageVector.append(vector<u8>[0]);
         let bls_sig = BLS_SIG_0;
         let house_public_key = HOUSE_PUBLIC_KEY;
         let is_sig_valid = bls12381_min_pk_verify(
@@ -79,359 +75,342 @@ module blackjack::single_player_blackjack_tests {
 
     #[test]
     fun test_initialize_house_data() {
-        let mut scenario_val = test_scenario::begin(ADMIN);
-        let scenario = &mut scenario_val;
+        let mut scenario = test_scenario::begin(ADMIN);
 
-        initialize_house_data_for_test(scenario, ADMIN, INITIAL_HOUSE_BALANCE);
+        scenario.initialize_house_data_for_test(ADMIN, INITIAL_HOUSE_BALANCE);
 
-        test_scenario::next_tx(scenario, ADMIN);
+        scenario.next_tx(ADMIN);
         {
             // validate that the house data is created
-            let house_data = test_scenario::take_shared<HouseData>(scenario);
-            let house_data_balance = bj::balance(&house_data);
+            let house_data = scenario.take_shared<HouseData>();
+            let house_data_balance = house_data.balance();
             assert!(house_data_balance == INITIAL_HOUSE_BALANCE, 1);
-            assert!(bj::public_key(&house_data) == HOUSE_PUBLIC_KEY, 2);
-            assert!(bj::house(&house_data) == ADMIN, 3);
+            assert!(house_data.public_key() == HOUSE_PUBLIC_KEY, 2);
+            assert!(house_data.house() == ADMIN, 3);
             test_scenario::return_shared<HouseData>(house_data);
 
             // and that the adminHouseCap was burnt
-            let adminOwnedObjects: vector<ID> = test_scenario::ids_for_sender<HouseAdminCap>(scenario);
-            assert!(vector::length(&adminOwnedObjects) == 0, 2);
+            let adminOwnedObjects: vector<ID> = scenario.ids_for_sender<HouseAdminCap>();
+            assert!(adminOwnedObjects.length() == 0, 2);
         };
 
-        test_scenario::end(scenario_val);
+        scenario.end();
     }
 
     #[test]
     fun test_top_up_house_data() {
-        let mut scenario_val = test_scenario::begin(ADMIN);
-        let scenario = &mut scenario_val;
+        let mut scenario = test_scenario::begin(ADMIN);
 
-        initialize_house_data_for_test(scenario, ADMIN, INITIAL_HOUSE_BALANCE);
+        scenario.initialize_house_data_for_test(ADMIN, INITIAL_HOUSE_BALANCE);
 
-        test_scenario::next_tx(scenario, ADMIN);
+        scenario.next_tx(ADMIN);
         {
-            let coin = coin::mint_for_testing<SUI>(50000, test_scenario::ctx(scenario));
+            let coin = coin::mint_for_testing<SUI>(50000, scenario.ctx());
             transfer::public_transfer(coin, ADMIN);
         };
 
-        test_scenario::next_tx(scenario, ADMIN);
+        scenario.next_tx(ADMIN);
         {
-            let mut house_data = test_scenario::take_shared<HouseData>(scenario);
-            let fund_coin = test_scenario::take_from_sender<Coin<SUI>>(scenario);
-            bj::top_up(&mut house_data, fund_coin, test_scenario::ctx(scenario));
+            let mut house_data = scenario.take_shared<HouseData>();
+            let fund_coin = scenario.take_from_sender<Coin<SUI>>();
+            house_data.top_up(fund_coin, scenario.ctx());
             test_scenario::return_shared(house_data);
         };
 
-        test_scenario::next_tx(scenario, ADMIN);
+        scenario.next_tx(ADMIN);
         {
-            let house_data = test_scenario::take_shared<HouseData>(scenario);
-            assert!(bj::balance(&house_data) == INITIAL_HOUSE_BALANCE + 50000, 1);
+            let house_data = scenario.take_shared<HouseData>();
+            assert!(house_data.balance() == INITIAL_HOUSE_BALANCE + 50000, 1);
             test_scenario::return_shared(house_data);
         };
 
-        test_scenario::end(scenario_val);
+        scenario.end();
     }
 
     #[test]
     fun test_withdraw_from_house_data() {
-        let mut scenario_val = test_scenario::begin(ADMIN);
-        let scenario = &mut scenario_val;
+        let mut scenario = test_scenario::begin(ADMIN);
 
-        initialize_house_data_for_test(scenario, ADMIN, INITIAL_HOUSE_BALANCE);
+        scenario.initialize_house_data_for_test(ADMIN, INITIAL_HOUSE_BALANCE);
 
-        test_scenario::next_tx(scenario, ADMIN);
+        scenario.next_tx(ADMIN);
         {
-            let mut house_data = test_scenario::take_shared<HouseData>(scenario);
-            bj::withdraw(&mut house_data, test_scenario::ctx(scenario));
+            let mut house_data = scenario.take_shared<HouseData>();
+            house_data.withdraw(scenario.ctx());
             test_scenario::return_shared(house_data);
         };
 
-        test_scenario::next_tx(scenario, ADMIN);
+        scenario.next_tx(ADMIN);
         {
-            let house_data = test_scenario::take_shared<HouseData>(scenario);
-            assert!(bj::balance(&house_data) == 0, 1);
+            let house_data = scenario.take_shared<HouseData>();
+            assert!(house_data.balance() == 0, 1);
             test_scenario::return_shared(house_data);
         };
 
-        test_scenario::end(scenario_val);
+        scenario.end();
     }
 
     #[test]
     #[expected_failure(abort_code = bj::EInsufficientBalance)]
     fun test_initialize_house_data_with_insifficient_balance() {
-        let mut scenario_val = test_scenario::begin(ADMIN);
-        let scenario = &mut scenario_val;
+        let mut scenario = test_scenario::begin(ADMIN);
 
-        initialize_house_data_for_test(scenario, ADMIN, 0);
+        scenario.initialize_house_data_for_test(ADMIN, 0);
 
-        test_scenario::end(scenario_val);
+        scenario.end();
     }
 
     #[test]
     fun test_place_bet_and_create_game() {
-        let mut scenario_val = test_scenario::begin(PLAYER);
-        let scenario = &mut scenario_val;
+        let mut scenario = test_scenario::begin(PLAYER);
 
-        initialize_house_data_for_test(scenario, ADMIN, INITIAL_HOUSE_BALANCE);
-        initialize_game_for_test(scenario, PLAYER, PLAYER_BET);
+        scenario.initialize_house_data_for_test(ADMIN, INITIAL_HOUSE_BALANCE);
+        scenario.initialize_game_for_test(PLAYER, PLAYER_BET);
 
-        test_scenario::next_tx(scenario, PLAYER);
+        scenario.next_tx(PLAYER);
         {
-            let game = test_scenario::take_shared<Game>(scenario);
-            assert!(bj::player(&game) == PLAYER, 2);
-            assert!(bj::player_cards(&game) == vector[], 3);
-            assert!(bj::player_sum(&game) == 0, 4);
-            assert!(bj::dealer_cards(&game) == vector[], 5);
-            assert!(bj::dealer_sum(&game) == 0, 6);
-            assert!(bj::status(&game) == 0, 7);
-            assert!(bj::total_stake(&game) == HOUSE_BET + PLAYER_BET, 8);
+            let game = scenario.take_shared<Game>();
+            assert!(game.player() == PLAYER, 2);
+            assert!(game.player_cards() == vector[], 3);
+            assert!(game.player_sum() == 0, 4);
+            assert!(game.dealer_cards() == vector[], 5);
+            assert!(game.dealer_sum() == 0, 6);
+            assert!(game.status() == 0, 7);
+            assert!(game.total_stake() == HOUSE_BET + PLAYER_BET, 8);
             test_scenario::return_shared(game);
         };
 
-        test_scenario::end(scenario_val);
+        scenario.end();
     }
 
     #[test]
     #[expected_failure(abort_code = bj::EInsufficientHouseBalance)]
     fun test_place_bet_and_create_game_insufficient_house_balance() {
-        let mut scenario_val = test_scenario::begin(ADMIN);
-        let scenario = &mut scenario_val;
+        let mut scenario = test_scenario::begin(ADMIN);
 
-        initialize_house_data_for_test(scenario, ADMIN, HOUSE_BET - 1);
-        initialize_game_for_test(scenario, PLAYER, PLAYER_BET);
+        scenario.initialize_house_data_for_test(ADMIN, HOUSE_BET - 1);
+        scenario.initialize_game_for_test(PLAYER, PLAYER_BET);
 
-        test_scenario::end(scenario_val);
+        scenario.end();
     }
 
     #[test]
     #[expected_failure(abort_code = bj::EInvalidPlayerBetAmount)]
     fun test_place_bet_and_create_game_insufficient_balance() {
-        let mut scenario_val = test_scenario::begin(ADMIN);
-        let scenario = &mut scenario_val;
+        let mut scenario = test_scenario::begin(ADMIN);
 
-        initialize_house_data_for_test(scenario, ADMIN, INITIAL_HOUSE_BALANCE);
-        initialize_game_for_test(scenario, PLAYER, PLAYER_BET - 1);
+        scenario.initialize_house_data_for_test(ADMIN, INITIAL_HOUSE_BALANCE);
+        scenario.initialize_game_for_test(PLAYER, PLAYER_BET - 1);
 
-        test_scenario::end(scenario_val);
+        scenario.end();
     }
 
     #[test]
     fun test_first_deal() {
-        let mut scenario_val = test_scenario::begin(PLAYER);
-        let scenario = &mut scenario_val;
+        let mut scenario = test_scenario::begin(PLAYER);
 
-        initialize_house_data_for_test(scenario, ADMIN, INITIAL_HOUSE_BALANCE);
-        initialize_game_for_test(scenario, PLAYER, PLAYER_BET);
-        do_first_deal_for_test(scenario, ADMIN, BLS_SIG_0, false);
+        scenario.initialize_house_data_for_test(ADMIN, INITIAL_HOUSE_BALANCE);
+        scenario.initialize_game_for_test(PLAYER, PLAYER_BET);
+        scenario.do_first_deal_for_test(ADMIN, BLS_SIG_0, false);
 
-        test_scenario::next_tx(scenario, ADMIN);
+        scenario.next_tx(ADMIN);
         {
-            let game = test_scenario::take_shared<Game>(scenario);
-            assert!(bj::player_sum(&game) > 0, 1);
-            assert!(bj::dealer_sum(&game) > 0, 2);
-            assert!(vector::length(&bj::player_cards(&game)) == 2, 3);
-            assert!(vector::length(&bj::dealer_cards(&game)) == 1, 4);
+            let game = scenario.take_shared<Game>();
+            assert!(game.player_sum() > 0, 1);
+            assert!(game.dealer_sum() > 0, 2);
+            assert!(game.player_cards().length() == 2, 3);
+            assert!(game.dealer_cards().length() == 1, 4);
             test_scenario::return_shared(game);
         };
 
-        test_scenario::end(scenario_val);
+        scenario.end();
     }
 
      #[test]
      #[expected_failure(abort_code = bj::EInvalidBlsSig)]
     fun test_first_deal_with_invalid_bls_sig() {
-        let mut scenario_val = test_scenario::begin(PLAYER);
-        let scenario = &mut scenario_val;
+        let mut scenario = test_scenario::begin(PLAYER);
 
-        initialize_house_data_for_test(scenario, ADMIN, INITIAL_HOUSE_BALANCE);
-        initialize_game_for_test(scenario, PLAYER, PLAYER_BET);
-        do_first_deal_for_test(scenario, ADMIN, BLS_SIG_1, false);
+        scenario.initialize_house_data_for_test(ADMIN, INITIAL_HOUSE_BALANCE);
+        scenario.initialize_game_for_test(PLAYER, PLAYER_BET);
+        scenario.do_first_deal_for_test(ADMIN, BLS_SIG_1, false);
 
-        test_scenario::end(scenario_val);
+        scenario.end();
     }
 
     #[test]
     #[expected_failure(abort_code = bj::EDealAlreadyHappened)]
     public fun test_first_deal_twice() {
-        let mut scenario_val = test_scenario::begin(ADMIN);
-        let scenario = &mut scenario_val;
+        let mut scenario = test_scenario::begin(ADMIN);
 
-        initialize_house_data_for_test(scenario, ADMIN, INITIAL_HOUSE_BALANCE);
-        initialize_game_for_test(scenario, PLAYER, PLAYER_BET);
-        do_first_deal_for_test(scenario, ADMIN, BLS_SIG_0, false);
-        do_first_deal_for_test(scenario, ADMIN, BLS_SIG_1, false);
+        scenario.initialize_house_data_for_test(ADMIN, INITIAL_HOUSE_BALANCE);
+        scenario.initialize_game_for_test(PLAYER, PLAYER_BET);
+        scenario.do_first_deal_for_test(ADMIN, BLS_SIG_0, false);
+        scenario.do_first_deal_for_test(ADMIN, BLS_SIG_1, false);
 
-        test_scenario::end(scenario_val);
+        scenario.end();
     }
 
     #[test]
     fun test_hit() {
-        let mut scenario_val = test_scenario::begin(PLAYER);
-        let scenario = &mut scenario_val;
+        let mut scenario = test_scenario::begin(PLAYER);
 
-        initialize_house_data_for_test(scenario, ADMIN, INITIAL_HOUSE_BALANCE);
-        initialize_game_for_test(scenario, PLAYER, PLAYER_BET);
-        do_first_deal_for_test(scenario, ADMIN, BLS_SIG_0, false);
+        initialize_house_data_for_test(&mut scenario, ADMIN, INITIAL_HOUSE_BALANCE);
+        initialize_game_for_test(&mut scenario, PLAYER, PLAYER_BET);
+        scenario.do_first_deal_for_test(ADMIN, BLS_SIG_0, false);
 
         let mut _player_sum_before: u8 = 0;
         let mut _player_cards_before: vector<u8> = vector<u8>[];
         let mut _dealer_sum_before: u8 = 0;
         let mut _dealer_cards_before: vector<u8> = vector<u8>[];
 
-        test_scenario::next_tx(scenario, PLAYER);
+        scenario.next_tx(PLAYER);
         {
-            let game = test_scenario::take_shared<Game>(scenario);
-            _player_sum_before = bj::player_sum(&game);
-            _player_cards_before = bj::player_cards(&game);
-            _dealer_sum_before = bj::dealer_sum(&game);
-            _dealer_cards_before = bj::dealer_cards(&game);
+            let game = scenario.take_shared<Game>();
+            _player_sum_before = game.player_sum();
+            _player_cards_before = game.player_cards();
+            _dealer_sum_before = game.dealer_sum();
+            _dealer_cards_before = game.dealer_cards();
             test_scenario::return_shared(game);
         };
 
-        do_hit_for_test(scenario, PLAYER, ADMIN);
-        hit_for_test(scenario, ADMIN, BLS_SIG_1);
+        scenario.do_hit_for_test(PLAYER, ADMIN);
+        scenario.hit_for_test(ADMIN, BLS_SIG_1);
 
-        test_scenario::next_tx(scenario, ADMIN);
+        scenario.next_tx(ADMIN);
         {
-            let game = test_scenario::take_shared<Game>(scenario);
-            let owned_hit_requests_by_admin = test_scenario::ids_for_sender<HitRequest>(scenario);
-            let player_cards_length_before = vector::length(&_player_cards_before);
-            let player_cards_length_after = vector::length(&bj::player_cards(&game));
-            let dealer_cards_length_before = vector::length(&_dealer_cards_before);
-            let dealer_cards_length_after = vector::length(&bj::dealer_cards(&game));
+            let game = scenario.take_shared<Game>();
+            let owned_hit_requests_by_admin = scenario.ids_for_sender<HitRequest>();
+            let player_cards_length_before = _player_cards_before.length();
+            let player_cards_length_after = game.player_cards().length();
+            let dealer_cards_length_before = _dealer_cards_before.length();
+            let dealer_cards_length_after = game.dealer_cards().length();
 
-            assert!(vector::length(&owned_hit_requests_by_admin) == 0, 1);
-            assert!(bj::player_sum(&game) > _player_sum_before, 1);
+            assert!(owned_hit_requests_by_admin.length() == 0, 1);
+            assert!(game.player_sum() > _player_sum_before, 1);
             assert!(player_cards_length_after == player_cards_length_before + 1, 2);
-            assert!(bj::dealer_sum(&game) == _dealer_sum_before, 3);
+            assert!(game.dealer_sum() == _dealer_sum_before, 3);
             assert!(dealer_cards_length_after == dealer_cards_length_before, 4);
             test_scenario::return_shared(game);
         };
 
-        test_scenario::end(scenario_val);
+        scenario.end();
     }
 
     #[test]
     fun test_stand() {
-        let mut scenario_val = test_scenario::begin(PLAYER);
-        let scenario = &mut scenario_val;
+        let mut scenario = test_scenario::begin(PLAYER);
 
-        initialize_house_data_for_test(scenario, ADMIN, INITIAL_HOUSE_BALANCE);
-        initialize_game_for_test(scenario, PLAYER, PLAYER_BET);
-        do_first_deal_for_test(scenario, ADMIN, BLS_SIG_0, false);
+        scenario.initialize_house_data_for_test(ADMIN, INITIAL_HOUSE_BALANCE);
+        scenario.initialize_game_for_test(PLAYER, PLAYER_BET);
+        scenario.do_first_deal_for_test(ADMIN, BLS_SIG_0, false);
 
         let mut _player_sum_before: u8 = 0;
         let mut _player_cards_before: vector<u8> = vector<u8>[];
         let mut _dealer_sum_before: u8 = 0;
         let mut _dealer_cards_before: vector<u8> = vector<u8>[];
 
-        test_scenario::next_tx(scenario, PLAYER);
+        scenario.next_tx(PLAYER);
         {
-            let game = test_scenario::take_shared<Game>(scenario);
-            _player_sum_before = bj::player_sum(&game);
-            _player_cards_before = bj::player_cards(&game);
-            _dealer_sum_before = bj::dealer_sum(&game);
-            _dealer_cards_before = bj::dealer_cards(&game);
+            let game = scenario.take_shared<Game>();
+            _player_sum_before = game.player_sum();
+            _player_cards_before = game.player_cards();
+            _dealer_sum_before = game.dealer_sum();
+            _dealer_cards_before = game.dealer_cards();
             test_scenario::return_shared(game);
         };
 
-        do_stand_for_test(scenario, PLAYER, ADMIN);
-        stand_for_test(scenario, ADMIN, BLS_SIG_1);
+        scenario.do_stand_for_test(PLAYER, ADMIN);
+        scenario.stand_for_test(ADMIN, BLS_SIG_1);
 
-        test_scenario::next_tx(scenario, ADMIN);
+        scenario.next_tx(ADMIN);
         {
-            let game = test_scenario::take_shared<Game>(scenario);
-            let owned_stand_requests_by_admin = test_scenario::ids_for_sender<StandRequest>(scenario);
-            let player_cards_length_before = vector::length(&_player_cards_before);
-            let player_cards_length_after = vector::length(&bj::player_cards(&game));
-            let dealer_cards_length_before = vector::length(&_dealer_cards_before);
-            let dealer_cards_length_after = vector::length(&bj::dealer_cards(&game));
+            let game = scenario.take_shared<Game>();
+            let owned_stand_requests_by_admin = scenario.ids_for_sender<StandRequest>();
+            let player_cards_length_before = _player_cards_before.length();
+            let player_cards_length_after = game.player_cards().length();
+            let dealer_cards_length_before = _dealer_cards_before.length();
+            let dealer_cards_length_after = game.dealer_cards().length();
 
-            assert!(vector::length(&owned_stand_requests_by_admin) == 0, 1);
-            assert!(bj::player_sum(&game) == _player_sum_before, 1);
+            assert!(owned_stand_requests_by_admin.length() == 0, 1);
+            assert!(game.player_sum() == _player_sum_before, 1);
             assert!(player_cards_length_after == player_cards_length_before, 2);
-            assert!(bj::dealer_sum(&game) > _dealer_sum_before, 3);
+            assert!(game.dealer_sum() > _dealer_sum_before, 3);
             assert!(dealer_cards_length_after > dealer_cards_length_before, 4);
             test_scenario::return_shared(game);
         };
 
-        test_scenario::end(scenario_val);
+        scenario.end();
     }
 
     #[test]
     fun test_do_hit() {
-        let mut scenario_val = test_scenario::begin(PLAYER);
-        let scenario = &mut scenario_val;
+        let mut scenario = test_scenario::begin(PLAYER);
 
-        initialize_house_data_for_test(scenario, PLAYER, INITIAL_HOUSE_BALANCE);
-        initialize_game_for_test(scenario, PLAYER, PLAYER_BET);
-        do_first_deal_for_test(scenario, PLAYER, BLS_SIG_0, false);
-        do_hit_for_test(scenario, PLAYER, ADMIN);
+        scenario.initialize_house_data_for_test(PLAYER, INITIAL_HOUSE_BALANCE);
+        scenario.initialize_game_for_test(PLAYER, PLAYER_BET);
+        scenario.do_first_deal_for_test(PLAYER, BLS_SIG_0, false);
+        scenario.do_hit_for_test(PLAYER, ADMIN);
 
-        test_scenario::next_tx(scenario, ADMIN);
+        scenario.next_tx(ADMIN);
         {
-            let hit_request = test_scenario::take_from_sender<HitRequest>(scenario);
-            let game = test_scenario::take_shared<Game>(scenario);
+            let hit_request = scenario.take_from_sender<HitRequest>();
+            let game = scenario.take_shared<Game>();
 
-            assert!(bj::hit_request_game_id(&hit_request) == object::id(&game), 1);
-            assert!(bj::hit_request_current_player_sum(&hit_request) == bj::player_sum(&game), 2);
+            assert!(hit_request.hit_request_game_id() == object::id(&game), 1);
+            assert!(hit_request.hit_request_current_player_sum() == game.player_sum(), 2);
 
-            test_scenario::return_to_sender(scenario, hit_request);
+            scenario.return_to_sender(hit_request);
             test_scenario::return_shared(game);
         };
 
-        test_scenario::end(scenario_val);
+        scenario.end();
     }
 
     #[test]
     #[expected_failure(abort_code = bj::EGameHasFinished)]
     fun test_do_hit_in_finished_game() {
-        let mut scenario_val = test_scenario::begin(PLAYER);
-        let scenario = &mut scenario_val;
+        let mut scenario = test_scenario::begin(PLAYER);
 
-        initialize_house_data_for_test(scenario, ADMIN, INITIAL_HOUSE_BALANCE);
-        initialize_game_for_test(scenario, PLAYER, PLAYER_BET);
-        do_first_deal_for_test(scenario, ADMIN, BLS_SIG_0, false);
-        player_won_post_handling_for_test(scenario, ADMIN);
-        do_hit_for_test(scenario, PLAYER, ADMIN);
+        scenario.initialize_house_data_for_test(ADMIN, INITIAL_HOUSE_BALANCE);
+        scenario.initialize_game_for_test(PLAYER, PLAYER_BET);
+        scenario.do_first_deal_for_test(ADMIN, BLS_SIG_0, false);
+        scenario.player_won_post_handling_for_test(ADMIN);
+        scenario.do_hit_for_test(PLAYER, ADMIN);
 
-        test_scenario::end(scenario_val);
+        scenario.end();
     }
 
     #[test]
     #[expected_failure(abort_code = bj::EUnauthorizedPlayer)]
     fun test_do_hit_unauthorized() {
-        let mut scenario_val = test_scenario::begin(PLAYER);
-        let scenario = &mut scenario_val;
+        let mut scenario = test_scenario::begin(PLAYER);
         let player2 = @0xBBBB;
 
-        initialize_house_data_for_test(scenario, ADMIN, INITIAL_HOUSE_BALANCE);
-        initialize_game_for_test(scenario, PLAYER, PLAYER_BET);
-        do_first_deal_for_test(scenario, ADMIN, BLS_SIG_0, false);
-        do_hit_for_test(scenario, player2, ADMIN);
+        scenario.initialize_house_data_for_test(ADMIN, INITIAL_HOUSE_BALANCE);
+        scenario.initialize_game_for_test(PLAYER, PLAYER_BET);
+        scenario.do_first_deal_for_test(ADMIN, BLS_SIG_0, false);
+        scenario.do_hit_for_test(player2, ADMIN);
 
-        test_scenario::end(scenario_val);
+        scenario.end();
     }
 
     #[test]
     #[expected_failure(abort_code = bj::EInvalidSumOfHitRequest)]
     fun test_do_hit_with_invalid_player_sum() {
-        let mut scenario_val = test_scenario::begin(PLAYER);
-        let scenario = &mut scenario_val;
+        let mut scenario = test_scenario::begin(PLAYER);
 
-        initialize_house_data_for_test(scenario, ADMIN, INITIAL_HOUSE_BALANCE);
-        initialize_game_for_test(scenario, PLAYER, PLAYER_BET);
-        do_first_deal_for_test(scenario, ADMIN, BLS_SIG_0, false);
-        
-        test_scenario::next_tx(scenario, PLAYER);
+        scenario.initialize_house_data_for_test(ADMIN, INITIAL_HOUSE_BALANCE);
+        scenario.initialize_game_for_test(PLAYER, PLAYER_BET);
+        scenario.do_first_deal_for_test(ADMIN, BLS_SIG_0, false);
+
+        scenario.next_tx(PLAYER);
         {
-            let mut game = test_scenario::take_shared<Game>(scenario);
-            let current_player_sum = bj::player_sum(&game);
-            let hit_request = bj::do_hit(
-                &mut game,
+            let mut game = scenario.take_shared<Game>();
+            let current_player_sum = game.player_sum();
+            let hit_request = game.do_hit(
                 current_player_sum + 1,
-                test_scenario::ctx(scenario),
+                scenario.ctx(),
             );
             transfer::public_transfer(
                 hit_request,
@@ -440,81 +419,76 @@ module blackjack::single_player_blackjack_tests {
             test_scenario::return_shared(game);
         };
 
-        test_scenario::end(scenario_val);
+        scenario.end();
     }
 
     #[test]
     fun test_to_stand() {
-        let mut scenario_val = test_scenario::begin(PLAYER);
-        let scenario = &mut scenario_val;
+        let mut scenario = test_scenario::begin(PLAYER);
 
-        initialize_house_data_for_test(scenario, PLAYER, INITIAL_HOUSE_BALANCE);
-        initialize_game_for_test(scenario, PLAYER, PLAYER_BET);
-        do_first_deal_for_test(scenario, PLAYER, BLS_SIG_0, false);
-        do_stand_for_test(scenario, PLAYER, ADMIN);
+        scenario.initialize_house_data_for_test(PLAYER, INITIAL_HOUSE_BALANCE);
+        scenario.initialize_game_for_test(PLAYER, PLAYER_BET);
+        scenario.do_first_deal_for_test(PLAYER, BLS_SIG_0, false);
+        scenario.do_stand_for_test(PLAYER, ADMIN);
 
-        test_scenario::next_tx(scenario, ADMIN);
+        scenario.next_tx(ADMIN);
         {
-            let stand_request = test_scenario::take_from_sender<StandRequest>(scenario);
-            let game = test_scenario::take_shared<Game>(scenario);
+            let stand_request = scenario.take_from_sender<StandRequest>();
+            let game = scenario.take_shared<Game>();
 
-            assert!(bj::stand_request_game_id(&stand_request) == object::id(&game), 1);
-            assert!(bj::stand_request_current_player_sum(&stand_request) == bj::player_sum(&game), 2);
+            assert!(stand_request.stand_request_game_id() == object::id(&game), 1);
+            assert!(stand_request.stand_request_current_player_sum() == game.player_sum(), 2);
 
-            test_scenario::return_to_sender(scenario, stand_request);
+            scenario.return_to_sender(stand_request);
             test_scenario::return_shared(game);
         };
 
-        test_scenario::end(scenario_val);
+        scenario.end();
     }
 
     #[test]
     #[expected_failure(abort_code = bj::EGameHasFinished)]
     fun test_do_stand_in_finished_game() {
-        let mut scenario_val = test_scenario::begin(PLAYER);
-        let scenario = &mut scenario_val;
+        let mut scenario = test_scenario::begin(PLAYER);
 
-        initialize_house_data_for_test(scenario, ADMIN, INITIAL_HOUSE_BALANCE);
-        initialize_game_for_test(scenario, PLAYER, PLAYER_BET);
-        do_first_deal_for_test(scenario, ADMIN, BLS_SIG_0, false);
-        player_won_post_handling_for_test(scenario, ADMIN);
-        do_stand_for_test(scenario, PLAYER, ADMIN);
-        test_scenario::end(scenario_val);
+        scenario.initialize_house_data_for_test(ADMIN, INITIAL_HOUSE_BALANCE);
+        scenario.initialize_game_for_test(PLAYER, PLAYER_BET);
+        scenario.do_first_deal_for_test(ADMIN, BLS_SIG_0, false);
+        scenario.player_won_post_handling_for_test(ADMIN);
+        scenario.do_stand_for_test(PLAYER, ADMIN);
+        scenario.end();
     }
 
     #[test]
     #[expected_failure(abort_code = bj::EUnauthorizedPlayer)]
     fun test_do_stand_unauthorized() {
-        let mut scenario_val = test_scenario::begin(PLAYER);
-        let scenario = &mut scenario_val;
+        let mut scenario = test_scenario::begin(PLAYER);
         let player2 = @0xBBBB;
 
-        initialize_house_data_for_test(scenario, ADMIN, INITIAL_HOUSE_BALANCE);
-        initialize_game_for_test(scenario, PLAYER, PLAYER_BET);
-        do_first_deal_for_test(scenario, ADMIN, BLS_SIG_0, false);
-        do_stand_for_test(scenario, player2, ADMIN);
+        scenario.initialize_house_data_for_test(ADMIN, INITIAL_HOUSE_BALANCE);
+        scenario.initialize_game_for_test(PLAYER, PLAYER_BET);
+        scenario.do_first_deal_for_test(ADMIN, BLS_SIG_0, false);
+        scenario.do_stand_for_test(player2, ADMIN);
 
-        test_scenario::end(scenario_val);
+        scenario.end();
     }
 
     #[test]
     #[expected_failure(abort_code = bj::EInvalidSumOfStandRequest)]
     fun test_do_stand_with_invalid_player_sum() {
-        let mut scenario_val = test_scenario::begin(PLAYER);
-        let scenario = &mut scenario_val;
+        let mut scenario = test_scenario::begin(PLAYER);
 
-        initialize_house_data_for_test(scenario, ADMIN, INITIAL_HOUSE_BALANCE);
-        initialize_game_for_test(scenario, PLAYER, PLAYER_BET);
-        do_first_deal_for_test(scenario, ADMIN, BLS_SIG_0, false);
-        
-        test_scenario::next_tx(scenario, PLAYER);
+        scenario.initialize_house_data_for_test(ADMIN, INITIAL_HOUSE_BALANCE);
+        scenario.initialize_game_for_test(PLAYER, PLAYER_BET);
+        scenario.do_first_deal_for_test(ADMIN, BLS_SIG_0, false);
+
+        scenario.next_tx(PLAYER);
         {
-            let mut game = test_scenario::take_shared<Game>(scenario);
-            let current_player_sum = bj::player_sum(&game);
-            let stand_request = bj::do_stand(
-                &mut game,
+            let mut game = scenario.take_shared<Game>();
+            let current_player_sum = game.player_sum();
+            let stand_request = game.do_stand(
                 current_player_sum + 1,
-                test_scenario::ctx(scenario),
+                scenario.ctx(),
             );
             transfer::public_transfer(
                 stand_request,
@@ -523,142 +497,141 @@ module blackjack::single_player_blackjack_tests {
             test_scenario::return_shared(game);
         };
 
-        test_scenario::end(scenario_val);
+        scenario.end();
     }
 
     #[test]
     fun test_player_won_post_handling() {
-        let mut scenario_val = test_scenario::begin(PLAYER);
-        let scenario = &mut scenario_val;
-        initialize_house_data_for_test(scenario, ADMIN, INITIAL_HOUSE_BALANCE);
-        initialize_game_for_test(scenario, PLAYER, PLAYER_BET);
-        do_first_deal_for_test(scenario, ADMIN, BLS_SIG_0, false);
-        player_won_post_handling_for_test(scenario, ADMIN);
+        let mut scenario = test_scenario::begin(PLAYER);
+        scenario.initialize_house_data_for_test(ADMIN, INITIAL_HOUSE_BALANCE);
+        scenario.initialize_game_for_test(PLAYER, PLAYER_BET);
+        scenario.do_first_deal_for_test(ADMIN, BLS_SIG_0, false);
+        scenario.player_won_post_handling_for_test(ADMIN);
 
-        test_scenario::next_tx(scenario, PLAYER);
+        scenario.next_tx(PLAYER);
         {
-            let game = test_scenario::take_shared<Game>(scenario);
-            let house_data = test_scenario::take_shared<HouseData>(scenario);
-            assert!(bj::status(&game) == 1, 1);
-            assert!(bj::balance(&house_data) == INITIAL_HOUSE_BALANCE - HOUSE_BET, 2);
+            let game = scenario.take_shared<Game>();
+            let house_data = scenario.take_shared<HouseData>();
+            assert!(game.status() == 1, 1);
+            assert!(house_data.balance() == INITIAL_HOUSE_BALANCE - HOUSE_BET, 2);
             test_scenario::return_shared(game);
             test_scenario::return_shared(house_data);
         };
 
-        test_scenario::end(scenario_val);
+        scenario.end();
     }
 
     #[test]
     fun test_house_won_post_handling() {
-        let mut scenario_val = test_scenario::begin(PLAYER);
-        let scenario = &mut scenario_val;
-        initialize_house_data_for_test(scenario, ADMIN, INITIAL_HOUSE_BALANCE);
-        initialize_game_for_test(scenario, PLAYER, PLAYER_BET);
-        do_first_deal_for_test(scenario, ADMIN, BLS_SIG_0, false);
-        house_won_post_handling_for_test(scenario, ADMIN);
+        let mut scenario = test_scenario::begin(PLAYER);
+        scenario.initialize_house_data_for_test(ADMIN, INITIAL_HOUSE_BALANCE);
+        scenario.initialize_game_for_test(PLAYER, PLAYER_BET);
+        scenario.do_first_deal_for_test(ADMIN, BLS_SIG_0, false);
+        scenario.house_won_post_handling_for_test(ADMIN);
 
-        test_scenario::next_tx(scenario, PLAYER);
+        scenario.next_tx(PLAYER);
         {
-            let game = test_scenario::take_shared<Game>(scenario);
-            let house_data = test_scenario::take_shared<HouseData>(scenario);
-            assert!(bj::status(&game) == 2, 1);
-            assert!(bj::balance(&house_data) == INITIAL_HOUSE_BALANCE + PLAYER_BET, 2);
+            let game = scenario.take_shared<Game>();
+            let house_data = scenario.take_shared<HouseData>();
+            assert!(game.status() == 2, 1);
+            assert!(house_data.balance() == INITIAL_HOUSE_BALANCE + PLAYER_BET, 2);
             test_scenario::return_shared(game);
             test_scenario::return_shared(house_data);
         };
 
-        test_scenario::end(scenario_val);
+        scenario.end();
     }
 
     #[test]
     fun test_tie_post_handling() {
-        let mut scenario_val = test_scenario::begin(PLAYER);
-        let scenario = &mut scenario_val;
-        initialize_house_data_for_test(scenario, ADMIN, INITIAL_HOUSE_BALANCE);
-        initialize_game_for_test(scenario, PLAYER, PLAYER_BET);
-        do_first_deal_for_test(scenario, ADMIN, BLS_SIG_0, false);
-        tie_post_handling_for_test(scenario, ADMIN);
+        let mut scenario = test_scenario::begin(PLAYER);
+        scenario.initialize_house_data_for_test(ADMIN, INITIAL_HOUSE_BALANCE);
+        scenario.initialize_game_for_test(PLAYER, PLAYER_BET);
+        scenario.do_first_deal_for_test(ADMIN, BLS_SIG_0, false);
+        scenario.tie_post_handling_for_test(ADMIN);
 
-        test_scenario::next_tx(scenario, PLAYER);
+        scenario.next_tx(PLAYER);
         {
-            let game = test_scenario::take_shared<Game>(scenario);
-            let house_data = test_scenario::take_shared<HouseData>(scenario);
+            let game = scenario.take_shared<Game>();
+            let house_data = scenario.take_shared<HouseData>();
             let game_stake = HOUSE_BET + PLAYER_BET;
-            assert!(bj::status(&game) == 3, 1);
-            assert!(bj::balance(&house_data) == INITIAL_HOUSE_BALANCE - HOUSE_BET + game_stake/2, 2);
+            assert!(game.status() == 3, 1);
+            assert!(house_data.balance() == INITIAL_HOUSE_BALANCE - HOUSE_BET + game_stake/2, 2);
             test_scenario::return_shared(game);
             test_scenario::return_shared(house_data);
         };
 
-        test_scenario::end(scenario_val);
+        scenario.end();
     }
 
     // Test a whole flow where the user exceeds total sum of 21.
     #[test]
     fun test_player_exceeds_21() {
-        let mut scenario_val = test_scenario::begin(PLAYER);
-        let scenario = &mut scenario_val;
+        let mut scenario = test_scenario::begin(PLAYER);
 
-        initialize_house_data_for_test(scenario, ADMIN, INITIAL_HOUSE_BALANCE);
-        initialize_game_for_test(scenario, PLAYER, PLAYER_BET);
-        do_first_deal_for_test(scenario, ADMIN, BLS_SIG_0, false);
-        draw_card_seven_for_player_for_test(scenario, PLAYER, false);
-        do_hit_for_test(scenario, PLAYER, ADMIN);
-        hit_for_test(scenario, ADMIN, BLS_SIG_1);
+        scenario.initialize_house_data_for_test(ADMIN, INITIAL_HOUSE_BALANCE);
+        scenario.initialize_game_for_test(PLAYER, PLAYER_BET);
+        scenario.do_first_deal_for_test(ADMIN, BLS_SIG_0, false);
+        scenario.draw_card_seven_for_player_for_test(PLAYER, false);
+        scenario.do_hit_for_test(PLAYER, ADMIN);
+        scenario.hit_for_test(ADMIN, BLS_SIG_1);
 
-        test_scenario::next_tx(scenario, ADMIN);
+        scenario.next_tx(ADMIN);
         {
-            let house_data = test_scenario::take_shared<HouseData>(scenario);
-            let game = test_scenario::take_shared<Game>(scenario);
-            assert!(bj::balance(&house_data) == INITIAL_HOUSE_BALANCE + PLAYER_BET, 1);
-            assert!(bj::status(&game) == 2, 2);
+            let house_data = scenario.take_shared<HouseData>();
+            let game = scenario.take_shared<Game>();
+            assert!(house_data.balance() == INITIAL_HOUSE_BALANCE + PLAYER_BET, 1);
+            assert!(game.status() == 2, 2);
             test_scenario::return_shared(house_data);
             test_scenario::return_shared(game);
         };
 
-        test_scenario::end(scenario_val);
+        scenario.end();
     }
 
     //  --- Helper functions ---
+
+    use fun initialize_house_data_for_test as Scenario.initialize_house_data_for_test;
 
     fun initialize_house_data_for_test(
         scenario: &mut Scenario,
         admin: address,
         balance: u64,
     ) {
-        test_scenario::next_tx(scenario, admin);
+        scenario.next_tx(admin);
         {
-            bj::get_and_transfer_house_admin_cap_for_testing(test_scenario::ctx(scenario));
+            bj::get_and_transfer_house_admin_cap_for_testing(scenario.ctx());
         };
 
-        test_scenario::next_tx(scenario, admin);
+        scenario.next_tx(admin);
         {
-            let house_cap = test_scenario::take_from_sender<HouseAdminCap>(scenario);
-            let coin = coin::mint_for_testing<SUI>(balance, test_scenario::ctx(scenario));
-            bj::initialize_house_data(
-                house_cap,
+            let house_cap = scenario.take_from_sender<HouseAdminCap>();
+            let coin = coin::mint_for_testing<SUI>(balance, scenario.ctx());
+            house_cap.initialize_house_data(
                 coin,
                 HOUSE_PUBLIC_KEY,
-                test_scenario::ctx(scenario),
+                scenario.ctx(),
             );
         }
     }
+
+    use fun initialize_game_for_test as Scenario.initialize_game_for_test;
 
     fun initialize_game_for_test(
         scenario: &mut Scenario,
         player: address,
         balance: u64,
     ) {
-        test_scenario::next_tx(scenario, player);
+        scenario.next_tx(player);
         {
-            counter_nft::mint_and_transfer(test_scenario::ctx(scenario));
+            counter_nft::mint_and_transfer(scenario.ctx());
         };
 
-        test_scenario::next_tx(scenario, player);
+        scenario.next_tx(player);
         {
-            let mut counter = test_scenario::take_from_sender<Counter>(scenario);
-            let coin = coin::mint_for_testing<SUI>(balance, test_scenario::ctx(scenario));
-            let mut house_data = test_scenario::take_shared<HouseData>(scenario);
+            let mut counter = scenario.take_from_sender<Counter>();
+            let coin = coin::mint_for_testing<SUI>(balance, scenario.ctx());
+            let mut house_data = scenario.take_shared<HouseData>();
             bj::place_bet_and_create_game(
                 // Just a placeholder for the user_randomness.
                 // Will be replaced with a hard-coded value in the testing flow
@@ -667,23 +640,25 @@ module blackjack::single_player_blackjack_tests {
                 &mut counter,
                 coin,
                 &mut house_data,
-                test_scenario::ctx(scenario),
+                scenario.ctx(),
             );
-            test_scenario::return_to_sender(scenario, counter);
+            scenario.return_to_sender(counter);
             test_scenario::return_shared(house_data);
         };
 
-        test_scenario::next_tx(scenario, player);
+        scenario.next_tx(player);
         {
-            let mut game = test_scenario::take_shared<Game>(scenario);
+            let mut game = scenario.take_shared<Game>();
             bj::set_game_randomness_for_testing(
                 GAME_RANDOMNESS,
                 &mut game,
-                test_scenario::ctx(scenario),
+                scenario.ctx(),
             );
             test_scenario::return_shared(game);
         };
     }
+
+    use fun do_first_deal_for_test as Scenario.do_first_deal_for_test;
 
     fun do_first_deal_for_test(
         scenario: &mut Scenario,
@@ -691,44 +666,44 @@ module blackjack::single_player_blackjack_tests {
         bls_sig: vector<u8>,
         log_points: bool,
     ) {
-        test_scenario::next_tx(scenario, admin);
+        scenario.next_tx(admin);
         {
-            let mut game = test_scenario::take_shared<Game>(scenario);
-            let mut house_data = test_scenario::take_shared<HouseData>(scenario);
-            bj::first_deal(
-                &mut game,
+            let mut game = scenario.take_shared<Game>();
+            let mut house_data = scenario.take_shared<HouseData>();
+            game.first_deal(
                 bls_sig,
                 &mut house_data,
-                test_scenario::ctx(scenario),
+                scenario.ctx(),
             );
             test_scenario::return_shared(game);
             test_scenario::return_shared(house_data);
         };
 
         if (log_points) {
-            test_scenario::next_tx(scenario, admin);
+            scenario.next_tx(admin);
             {
-                let game = test_scenario::take_shared<Game>(scenario);
+                let game = scenario.take_shared<Game>();
                 debug::print(&utf8(b"player points after first deal:"));
-                debug::print(&bj::player_sum(&game));
+                debug::print(&game.player_sum());
                 test_scenario::return_shared(game);
             };
         }
     }
+
+    use fun do_hit_for_test as Scenario.do_hit_for_test;
 
     fun do_hit_for_test(
         scenario: &mut Scenario,
         player: address,
         admin: address,
     ) {
-        test_scenario::next_tx(scenario, player);
+        scenario.next_tx(player);
         {
-            let mut game = test_scenario::take_shared<Game>(scenario);
-            let current_player_sum = bj::player_sum(&game);
-            let hit_request = bj::do_hit(
-                &mut game,
+            let mut game = scenario.take_shared<Game>();
+            let current_player_sum = game.player_sum();
+            let hit_request = game.do_hit(
                 current_player_sum,
-                test_scenario::ctx(scenario),
+                scenario.ctx(),
             );
             transfer::public_transfer(
                 hit_request,
@@ -738,19 +713,20 @@ module blackjack::single_player_blackjack_tests {
         };
     }
 
+    use fun do_stand_for_test as Scenario.do_stand_for_test;
+
     fun do_stand_for_test(
         scenario: &mut Scenario,
         player: address,
         admin: address,
     ) {
-        let effects = test_scenario::next_tx(scenario, player);
+        let effects = scenario.next_tx(player);
         {
-            let mut game = test_scenario::take_shared<Game>(scenario);
-            let current_player_sum = bj::player_sum(&game);
-            let stand_request = bj::do_stand(
-                &mut game,
+            let mut game = scenario.take_shared<Game>();
+            let current_player_sum = game.player_sum();
+            let stand_request = game.do_stand(
                 current_player_sum,
-                test_scenario::ctx(scenario),
+                scenario.ctx(),
             );
             transfer::public_transfer(
                 stand_request,
@@ -761,123 +737,121 @@ module blackjack::single_player_blackjack_tests {
         effects;
     }
 
+    use fun hit_for_test as Scenario.hit_for_test;
+
     fun hit_for_test(
         scenario: &mut Scenario,
         admin: address,
         bls_sig: vector<u8>,
     ) {
-        test_scenario::next_tx(scenario, admin);
+        scenario.next_tx(admin);
         {
-            let mut game = test_scenario::take_shared<Game>(scenario);
-            let mut house_data = test_scenario::take_shared<HouseData>(scenario);
-            let hit_request = test_scenario::take_from_sender<HitRequest>(scenario);
-            bj::hit(
-                &mut game,
+            let mut game = scenario.take_shared<Game>();
+            let mut house_data = scenario.take_shared<HouseData>();
+            let hit_request = scenario.take_from_sender<HitRequest>();
+            game.hit(
                 bls_sig,
                 &mut house_data,
                 hit_request,
-                test_scenario::ctx(scenario),
+                scenario.ctx(),
             );
             test_scenario::return_shared(game);
             test_scenario::return_shared(house_data);
         };
     }
+
+    use fun stand_for_test as Scenario.stand_for_test;
 
     fun stand_for_test(
         scenario: &mut Scenario,
         admin: address,
         bls_sig: vector<u8>,
     ) {
-        test_scenario::next_tx(scenario, admin);
+        scenario.next_tx(admin);
         {
-            let mut game = test_scenario::take_shared<Game>(scenario);
-            let mut house_data = test_scenario::take_shared<HouseData>(scenario);
-            let stand_request = test_scenario::take_from_sender<StandRequest>(scenario);
-            bj::stand(
-                &mut game,
+            let mut game = scenario.take_shared<Game>();
+            let mut house_data = scenario.take_shared<HouseData>();
+            let stand_request = scenario.take_from_sender<StandRequest>();
+            game.stand(
                 bls_sig,
                 &mut house_data,
                 stand_request,
-                test_scenario::ctx(scenario),
+                scenario.ctx(),
             );
             test_scenario::return_shared(game);
             test_scenario::return_shared(house_data);
         };
     }
+
+    use fun draw_card_seven_for_player_for_test as Scenario.draw_card_seven_for_player_for_test;
 
     fun draw_card_seven_for_player_for_test(
         scenario: &mut Scenario,
         player: address,
         log_points: bool,
     ) {
-        test_scenario::next_tx(scenario, player);
+        scenario.next_tx(player);
         {
-            let mut game = test_scenario::take_shared<Game>(scenario);
+            let mut game = scenario.take_shared<Game>();
             let card = 6; // calculated value for card is 7
-            bj::draw_player_card_for_testing(
-                &mut game,
+            game.draw_player_card_for_testing(
                 card,
             );
             test_scenario::return_shared(game);
         };
 
         if (log_points) {
-            test_scenario::next_tx(scenario, player);
+            scenario.next_tx(player);
             {
-                let game = test_scenario::take_shared<Game>(scenario);
+                let game = scenario.take_shared<Game>();
                 debug::print(&utf8(b"player points after drawing seven:"));
-                debug::print(&bj::player_sum(&game));
+                debug::print(&game.player_sum());
                 test_scenario::return_shared(game);
             };
         }
     }
 
+    use fun player_won_post_handling_for_test as Scenario.player_won_post_handling_for_test;
+
     fun player_won_post_handling_for_test(
         scenario: &mut Scenario,
         admin: address,
     ) {
-        test_scenario::next_tx(scenario, admin);
+        scenario.next_tx(admin);
         {
-            let mut game = test_scenario::take_shared<Game>(scenario);
-            bj::player_won_post_handling_for_test(
-                &mut game,
-                test_scenario::ctx(scenario),
-            );
+            let mut game = scenario.take_shared<Game>();
+            game.player_won_post_handling_for_test(scenario.ctx());
             test_scenario::return_shared(game);
         };
     }
+
+    use fun house_won_post_handling_for_test as Scenario.house_won_post_handling_for_test;
 
     fun house_won_post_handling_for_test(
         scenario: &mut Scenario,
         admin: address,
     ) {
-        test_scenario::next_tx(scenario, admin);
+        scenario.next_tx(admin);
         {
-            let mut game = test_scenario::take_shared<Game>(scenario);
-            let mut house_data = test_scenario::take_shared<HouseData>(scenario);
-            bj::house_won_post_handling_for_test(
-                &mut game,
-                &mut house_data,
-                test_scenario::ctx(scenario),
-            );
+            let mut game = scenario.take_shared<Game>();
+            let mut house_data = scenario.take_shared<HouseData>();
+            game.house_won_post_handling_for_test(&mut house_data, scenario.ctx());
             test_scenario::return_shared(game);
             test_scenario::return_shared(house_data);
         };
     }
 
+    use fun tie_post_handling_for_test as Scenario.tie_post_handling_for_test;
+
     fun tie_post_handling_for_test(
         scenario: &mut Scenario,
         admin: address,
     ) {
-        test_scenario::next_tx(scenario, admin);
+        scenario.next_tx(admin);
         {
-            let mut game = test_scenario::take_shared<Game>(scenario);
-            let mut house_data = test_scenario::take_shared<HouseData>(scenario);
-            bj::tie_post_handling_for_test(
-                &mut game,
-                &mut house_data,
-                test_scenario::ctx(scenario),
-            );
+            let mut game = scenario.take_shared<Game>();
+            let mut house_data = scenario.take_shared<HouseData>();
+            game.tie_post_handling_for_test(&mut house_data, scenario.ctx());
             test_scenario::return_shared(game);
             test_scenario::return_shared(house_data);
         };

--- a/move/blackjack/tests/blackjack_tests.move
+++ b/move/blackjack/tests/blackjack_tests.move
@@ -5,7 +5,6 @@
 module blackjack::single_player_blackjack_tests {
 
     use std::debug;
-    use std::string::utf8;
     use sui::coin::{Coin, Self};
     use sui::sui::SUI;
     use sui::test_scenario::{Self, Scenario};
@@ -683,7 +682,7 @@ module blackjack::single_player_blackjack_tests {
             scenario.next_tx(admin);
             {
                 let game = scenario.take_shared<Game>();
-                debug::print(&utf8(b"player points after first deal:"));
+                debug::print(&b"player points after first deal:".to_string());
                 debug::print(&game.player_sum());
                 test_scenario::return_shared(game);
             };
@@ -804,7 +803,7 @@ module blackjack::single_player_blackjack_tests {
             scenario.next_tx(player);
             {
                 let game = scenario.take_shared<Game>();
-                debug::print(&utf8(b"player points after drawing seven:"));
+                debug::print(&b"player points after drawing seven:".to_string());
                 debug::print(&game.player_sum());
                 test_scenario::return_shared(game);
             };

--- a/move/blackjack/tests/counter_tests.move
+++ b/move/blackjack/tests/counter_tests.move
@@ -11,51 +11,49 @@ module blackjack::counter_tests {
     fun test_mint_and_transfer() {
         let user = @0xAAAA;
 
-        let mut scenario_val = test_scenario::begin(user);
-        let scenario = &mut scenario_val;
+        let mut scenario = test_scenario::begin(user);
 
-        test_scenario::next_tx(scenario, user);
+        scenario.next_tx(user);
         {
-            counter_nft::mint_and_transfer(test_scenario::ctx(scenario));
+            counter_nft::mint_and_transfer(scenario.ctx());
         };
 
-        test_scenario::next_tx(scenario, user);
+        scenario.next_tx(user);
         {
-            let counter = test_scenario::take_from_sender<Counter>(scenario);
-            assert!(counter_nft::count(&counter) == 0, 1);
-            test_scenario::return_to_sender(scenario, counter);
+            let counter = scenario.take_from_sender<Counter>();
+            assert!(counter.count() == 0, 1);
+            scenario.return_to_sender(counter);
         };
 
-        test_scenario::end(scenario_val);
+        scenario.end();
     }
 
     #[test]
     fun test_increment() {
         let user = @0xAAAA;
 
-        let mut scenario_val = test_scenario::begin(user);
-        let scenario = &mut scenario_val;
+        let mut scenario = test_scenario::begin(user);
 
-        test_scenario::next_tx(scenario, user);
+        scenario.next_tx(user);
         {
-            counter_nft::mint_and_transfer(test_scenario::ctx(scenario));
+            counter_nft::mint_and_transfer(scenario.ctx());
         };
 
-        test_scenario::next_tx(scenario, user);
+        scenario.next_tx(user);
         {
-            let mut counter = test_scenario::take_from_sender<Counter>(scenario);
-            assert!(counter_nft::count(&counter) == 0, 1);
-            counter_nft::increment_and_get(&mut counter);
-            test_scenario::return_to_sender(scenario, counter);
+            let mut counter = scenario.take_from_sender<Counter>();
+            assert!(counter.count() == 0, 1);
+            counter.increment_and_get();
+            scenario.return_to_sender(counter);
         };
 
-        test_scenario::next_tx(scenario, user);
+        scenario.next_tx(user);
         {
-            let counter = test_scenario::take_from_sender<Counter>(scenario);
-            assert!(counter_nft::count(&counter) == 1, 1);
-            test_scenario::return_to_sender(scenario, counter);
+            let counter = scenario.take_from_sender<Counter>();
+            assert!(counter.count() == 1, 1);
+            scenario.return_to_sender(counter);
         };
 
-        test_scenario::end(scenario_val);
+        scenario.end();
     }
 }

--- a/move/blackjack/tests/counter_tests.move
+++ b/move/blackjack/tests/counter_tests.move
@@ -11,7 +11,7 @@ module blackjack::counter_tests {
     fun test_mint_and_transfer() {
         let user = @0xAAAA;
 
-        let scenario_val = test_scenario::begin(user);
+        let mut scenario_val = test_scenario::begin(user);
         let scenario = &mut scenario_val;
 
         test_scenario::next_tx(scenario, user);
@@ -33,7 +33,7 @@ module blackjack::counter_tests {
     fun test_increment() {
         let user = @0xAAAA;
 
-        let scenario_val = test_scenario::begin(user);
+        let mut scenario_val = test_scenario::begin(user);
         let scenario = &mut scenario_val;
 
         test_scenario::next_tx(scenario, user);
@@ -43,7 +43,7 @@ module blackjack::counter_tests {
 
         test_scenario::next_tx(scenario, user);
         {
-            let counter = test_scenario::take_from_sender<Counter>(scenario);
+            let mut counter = test_scenario::take_from_sender<Counter>(scenario);
             assert!(counter_nft::count(&counter) == 0, 1);
             counter_nft::increment_and_get(&mut counter);
             test_scenario::return_to_sender(scenario, counter);


### PR DESCRIPTION
This migrates the example to Move 2024 Beta.

Testing was done in two ways:

1. Comparing the bytecode before and after migration for the main code (no change)
2. Migrating the tests to Move 2024, and ensuring they still run

Careful review would be appreciated here.