### PR TITLE
Missing File-ending in setup/README.md

### DIFF
--- a/setup/README.md
+++ b/setup/README.md
@@ -118,5 +118,5 @@ Another approach is to use the custom `Scenario` class (as defined in `setup/src
 ```shell
 sui client switch --env testnet
 cd setup
-./publish testnet
+./publish.sh testnet
 ```


### PR DESCRIPTION
Just a minor typo in the `setup/README.md`

The section _Testnet Deployment_ features a command missing a file ending.