### PR TITLE
vlas/fix case twentyone

### DIFF
--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -118,6 +118,7 @@ const HomePage = () => {
             handleHit={handleHit}
             handleStand={handleStand}
             isMoveLoading={isMoveLoading || isInitialDealLoading}
+            playerPoints={game.player_sum}
           />
         )}
         {game.status !== 0 && (

--- a/app/src/components/home/GameActions.tsx
+++ b/app/src/components/home/GameActions.tsx
@@ -6,12 +6,14 @@ interface GameActionsProps {
   handleHit: () => void;
   handleStand: () => void;
   isMoveLoading: boolean;
+  playerPoints: number;
 }
 
 export const GameActions = ({
   handleHit,
   handleStand,
   isMoveLoading,
+  playerPoints,
 }: GameActionsProps) => {
   return (
     <div className="flex justify-center space-x-[15px] items-center py-5">
@@ -19,6 +21,7 @@ export const GameActions = ({
         onClick={handleHit}
         isLoading={isMoveLoading}
         showSpinner={false}
+        disabled={playerPoints === 21}
         className="flex space-x-2 w-[150px] bg-transparent hover:bg-[#14C57A] border-[2px] rounded-[38px] !py-[16px] !px-[20px]"
       >
         <Image

--- a/move/blackjack/sources/single_player_blackjack.move
+++ b/move/blackjack/sources/single_player_blackjack.move
@@ -280,7 +280,7 @@ module blackjack::single_player_blackjack {
             current_player_hand_sum: game.player_sum,
             player_cards: game.player_cards
         });
-        //on twenty-one, user must stand
+        //on twenty-one, player must stand
         if (game.player_sum == 21) {
             let player_sum = game.player_sum();
             let stand_request = game.do_stand(player_sum, ctx);
@@ -289,9 +289,10 @@ module blackjack::single_player_blackjack {
                 stand_request,
                 ctx);
         }
-        if (game.player_sum > 21) {
+        //player bust
+        else if (game.player_sum > 21) {
             game.house_won_post_handling(house_data, ctx);
-        } else{
+        } else {
             game.counter = game.counter + 1;
         }
     }
@@ -337,7 +338,7 @@ module blackjack::single_player_blackjack {
         if (game.dealer_sum > 21) {
             game.player_won_post_handling(b"Dealer Busted!", ctx);
         }
-        //case dealer got blackjack and user got twenty-one
+        //case dealer got blackjack and player got twenty-one
         //dealer wins
         else if (game.dealer_sum == 21
                  && game.player_sum == 21
@@ -355,7 +356,7 @@ module blackjack::single_player_blackjack {
             }
             else {
                 // Tie
-                //captures case where both dealer and user got twenty-one
+                //captures case where both dealer and player got twenty-one
                 game.tie_post_handling(house_data, ctx);
             }
         }
@@ -675,12 +676,34 @@ module blackjack::single_player_blackjack {
     }
 
     #[test_only]
-    public fun draw_player_card_for_testing(
+    public fun draw_card_for_testing(
         game: &mut Game,
-        card: u8,
+        is_dealer: bool,
+        card_idx: u8,
     ) {
-        game.player_cards.push_back(card);
-        game.player_sum = get_card_sum(&game.player_cards);
+        if (!is_dealer) {
+            game.player_cards.push_back(card_idx);
+            game.player_sum = get_card_sum(&game.player_cards);
+        } else {
+            game.dealer_cards.push_back(card_idx);
+            game.dealer_sum = get_card_sum(&game.dealer_cards);
+        };
+    }
+
+    #[test_only]
+    public fun pop_card_for_testing(
+        game: &mut Game,
+        is_dealer: bool
+    ) {
+        if (!is_dealer) {
+            assert!(!game.player_cards.is_empty(), 0);
+            game.player_cards.pop_back();
+            game.player_sum = get_card_sum(&game.player_cards);
+        } else {
+            assert!(!game.dealer_cards.is_empty(), 0);
+            game.dealer_cards.pop_back();
+            game.dealer_sum = get_card_sum(&game.dealer_cards);
+        };
     }
 
     #[test_only]

--- a/move/blackjack/sources/single_player_blackjack.move
+++ b/move/blackjack/sources/single_player_blackjack.move
@@ -34,6 +34,7 @@ module blackjack::single_player_blackjack {
     const EInvalidSumOfStandRequest: u64 = 19;
     const EInvalidPlayerBetAmount: u64 = 20;
     const ECallerNotHouse: u64 = 21;
+    const EInvalidTwentyOneSumOfHitRequest: u64 = 22;
 
     // Structs
 
@@ -280,17 +281,8 @@ module blackjack::single_player_blackjack {
             current_player_hand_sum: game.player_sum,
             player_cards: game.player_cards
         });
-        //on twenty-one, player must stand
-        if (game.player_sum == 21) {
-            let player_sum = game.player_sum();
-            let stand_request = game.do_stand(player_sum, ctx);
-            game.stand(bls_sig,
-                house_data,
-                stand_request,
-                ctx);
-        }
-        //player bust
-        else if (game.player_sum > 21) {
+        //on twenty-one, hit option to be disabled via UI
+        if (game.player_sum > 21) {
             game.house_won_post_handling(house_data, ctx);
         } else {
             game.counter = game.counter + 1;
@@ -369,6 +361,7 @@ module blackjack::single_player_blackjack {
         assert!(game.status == IN_PROGRESS, EGameHasFinished);
         assert!(ctx.sender() == game.player, EUnauthorizedPlayer);
         assert!(current_player_sum == game.player_sum, EInvalidSumOfHitRequest);
+        assert!(current_player_sum != 21, EInvalidTwentyOneSumOfHitRequest);
 
         HitRequest {
             id: object::new(ctx),

--- a/move/blackjack/sources/single_player_blackjack.move
+++ b/move/blackjack/sources/single_player_blackjack.move
@@ -280,6 +280,15 @@ module blackjack::single_player_blackjack {
             current_player_hand_sum: game.player_sum,
             player_cards: game.player_cards
         });
+        //on twenty-one, user must stand
+        if (game.player_sum == 21) {
+            let player_sum = game.player_sum();
+            let stand_request = game.do_stand(player_sum, ctx);
+            game.stand(bls_sig,
+                house_data,
+                stand_request,
+                ctx);
+        }
         if (game.player_sum > 21) {
             game.house_won_post_handling(house_data, ctx);
         } else{
@@ -328,6 +337,13 @@ module blackjack::single_player_blackjack {
         if (game.dealer_sum > 21) {
             game.player_won_post_handling(b"Dealer Busted!", ctx);
         }
+        //case dealer got blackjack and user got twenty-one
+        //dealer wins
+        else if (game.dealer_sum == 21
+                 && game.player_sum == 21
+                 && game.dealer_cards.length() == 2) {
+            game.house_won_post_handling(house_data, ctx);
+        }
         else {
             if (game.dealer_sum > game.player_sum) {
                 // House won
@@ -339,6 +355,7 @@ module blackjack::single_player_blackjack {
             }
             else {
                 // Tie
+                //captures case where both dealer and user got twenty-one
                 game.tie_post_handling(house_data, ctx);
             }
         }


### PR DESCRIPTION
1_) The player should be made to stand if she gets twenty-one on 3 cards or more. Currently the player is offered the option to either hit or stand.

This is fixed in the UI by disabling the option to hit on player twenty-one.

2_) When player gets 21, we should make sure the following: 

- if dealer< or > 21, player wins
- if dealer=21 on 3 cards or more, it’s a tie.
- if dealer=21 on 2 cards (blackjack), dealer wins.

Test evidence:
1_) Hit button disabled on user twenty-one. Tested with John-Atha.

2_) Added move unit tests for new cases
test_player_stand_at_21_and_win()
test_player_stand_at_21_dealer_bj_and_win()
test_player_dealer_both_have_21_tie()
