### PR TITLE
feat: migrate to Move 2024 edition

### DIFF
--- a/move/blackjack/Move.toml
+++ b/move/blackjack/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "blackjack"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet" }


### PR DESCRIPTION
Migrate Move package to 2024 edition by following this guide: https://blog.sui.io/move-2024-migration-guide/?utm_source=forum&utm_medium=organic&utm_campaign=build_beyond

